### PR TITLE
修复Okam中使用redux，后台返回后redux失效问题

### DIFF
--- a/packages/okam-core/src/extend/data/redux/index.js
+++ b/packages/okam-core/src/extend/data/redux/index.js
@@ -11,7 +11,7 @@ import connect from './connect';
 
 function subscribeStoreChange() {
     if (this.__storeChangeHandler && !this.__unsubscribeStore) {
-        this.__unsubscribeStore = this.$app.$store.subscribe(
+        this.__unsubscribeStore = this.$store.subscribe(
             this.$fireStoreChange
         );
     }


### PR DESCRIPTION
发现在标题所述情况下，会报this.$app.$store.dispatch为空错误，检查发现去除$app后可以修复。整个文件也没有其他使用this.$app.$store的样例。
