### PR TITLE
fix: 解决小程序后台因为当前对象不存在而引起的 jserror

### DIFF
--- a/packages/okam-core/src/base/component.js
+++ b/packages/okam-core/src/base/component.js
@@ -70,7 +70,7 @@ export default {
         // call beforeDestroy hook
         this.beforeDestroy && this.beforeDestroy();
 
-        this.$listener.off();
+        this.$listener && this.$listener.off();
         this.$isDestroyed = true; // add destroyed flag
 
         // call destroyed hook

--- a/packages/okam-core/src/extend/data/observable/base.js
+++ b/packages/okam-core/src/extend/data/observable/base.js
@@ -189,7 +189,7 @@ export default {
         this.__setDataQueue = null;
         this.__upDoneCallbackQueue = null;
 
-        this.$dataListener.dispose();
+        this.$dataListener && this.$dataListener.dispose();
         this.$dataListener = null;
         this.__computedObserver && this.__computedObserver.dispose();
         this.__propsObserver = this.__dataObserver = this.__computedObserver = null;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31758094/115995820-570b2300-a60f-11eb-91b4-b756edb693f3.png)
![image](https://user-images.githubusercontent.com/31758094/115995833-65593f00-a60f-11eb-8ac7-bbd6ccaee75e.png)
小程序后台报错截图如上，会引起大量报错。添加断言可以避免相应问题。