### PR TITLE
fix: 解决onInit data初始化时, vuex因未初始化引起的报错

### DIFF
--- a/packages/okam-core/src/extend/data/vuex/index.js
+++ b/packages/okam-core/src/extend/data/vuex/index.js
@@ -34,6 +34,25 @@ function onStoreChange() {
     }
 }
 
+function initVuex() {
+    let store = this.$app.$store;
+    if (typeof store === 'function') {
+        store = store.call(this);
+    }
+
+    this.$fireStoreChange = onStoreChange.bind(this);
+    this.$subscribeStoreChange = subscribeStoreChange.bind(this);
+    this.$unsubscribeStoreChange = removeStoreChangeSubscribe.bind(this);
+    this.$store = store;
+
+    let computedInfo = this.$rawComputed || {};
+    if (typeof computedInfo === 'function') {
+        this.$rawComputed = computedInfo = computedInfo();
+    }
+
+    subscribeStoreChange.call(this);
+}
+
 // should use it at first, vuex store should be created after vuex plugin is enabled
 Vue.use(Vuex);
 
@@ -41,28 +60,22 @@ export default {
 
     component: {
 
+        onInit() {
+            initVuex.call(this);
+            this.__vuexInited = true;
+        },
+
         /**
          * The created hook when component created
          *
          * @private
          */
         beforeCreate() {
-            let store = this.$app.$store;
-            if (typeof store === 'function') {
-                store = store.call(this);
+            if (this.__vuexInited) {
+                return;
+            } else {
+                initVuex.call(this);
             }
-
-            this.$fireStoreChange = onStoreChange.bind(this);
-            this.$subscribeStoreChange = subscribeStoreChange.bind(this);
-            this.$unsubscribeStoreChange = removeStoreChangeSubscribe.bind(this);
-            this.$store = store;
-
-            let computedInfo = this.$rawComputed || {};
-            if (typeof computedInfo === 'function') {
-                this.$rawComputed = computedInfo = computedInfo();
-            }
-
-            subscribeStoreChange.call(this);
         },
 
         /**


### PR DESCRIPTION
**问题：**
引用了mapperGetters的页面会报错。
**原因猜测：**
okam在onInit进行computed 进行响应式处理，而vuex的初始化在 beforeCreate生命周期，此时引用vuex中的属性会引起报错（vue 还未初始化）。
**修改内容：**
把 vuex 的初始化提升到了 onInit，如果宿主无此生命周期仍旧在beforeCreate 进行。